### PR TITLE
Simplifying get_verify_status

### DIFF
--- a/scripts/helpful_scripts.py
+++ b/scripts/helpful_scripts.py
@@ -88,12 +88,7 @@ def fund_with_link(
 
 
 def get_verify_status():
-    verify = (
-        config["networks"][network.show_active()]["verify"]
-        if config["networks"][network.show_active()].get("verify")
-        else False
-    )
-    return verify
+    return config["networks"][network.show_active()].get("verify", False)
 
 
 def deploy_mocks(decimals=18, initial_value=2000):


### PR DESCRIPTION
Using the default value of dict's `get` instead of the ternary operator.