### PR TITLE
Remove duplicated requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 eth-brownie
 python-dotenv
-eth-brownie


### PR DESCRIPTION
Just noticed that `eth-brownie` shows up twice in `requirements.txt`

*Thanks for the tutorials Patrick!