### PR TITLE
fixes #47

### DIFF
--- a/contracts/test/VRFCoordinatorV2Mock.sol
+++ b/contracts/test/VRFCoordinatorV2Mock.sol
@@ -198,4 +198,8 @@ contract VRFCoordinatorV2Mock is VRFCoordinatorV2Interface {
   function acceptSubscriptionOwnerTransfer(uint64 _subId) external pure override {
     revert("not implemented");
   }
+
+  function pendingRequestExists(uint64 subId) external view returns (bool) {
+    revert("not implemented");
+  }
 }

--- a/contracts/test/VRFCoordinatorV2Mock.sol
+++ b/contracts/test/VRFCoordinatorV2Mock.sol
@@ -199,7 +199,7 @@ contract VRFCoordinatorV2Mock is VRFCoordinatorV2Interface {
     revert("not implemented");
   }
 
-  function pendingRequestExists(uint64 subId) external view returns (bool) {
+  function pendingRequestExists(uint64 _subId) external view returns (bool) {
     revert("not implemented");
   }
 }


### PR DESCRIPTION
added implementation for `pendingRequestExists` at `VRFCoordinatorV2Mock`. 